### PR TITLE
Add limit argument to API endpoint while maintaining backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This is a graphQL endpoint. The `astroObjects` schema accepts a single argument 
 Run the following command:
 
 ```bash
-gcloud functions deploy astro-objects-api --runtime nodejs14 --trigger-http --allow-unauthenticated
+sh deploy.sh
 ```
 
 The following environment variables must also be provided in the GCP console:
@@ -39,3 +39,4 @@ The following environment variables must also be provided in the GCP console:
 * DB_PASS
 * DB_NAME
 * DB_HOST
+* API_TOKEN

--- a/index.js
+++ b/index.js
@@ -110,6 +110,12 @@ const typeDefs = gql`
       dec: Float
       radius: Float
       mag: Float
+    ): [AstroObject]
+    getRangeOfAstroObjectsWithLimit(
+      ra: Float
+      dec: Float
+      radius: Float
+      mag: Float
       limit: Int
     ): [AstroObject]
   }
@@ -120,7 +126,23 @@ const getAstroObject = async (id) => {
   return res;
 };
 
-const getRangeOfAstroObjects = async (ra, dec, radius, mag, limit) => {
+const getRangeOfAstroObjects = async (ra, dec, radius, mag) => {
+  let res = await pool
+    .select()
+    .from("astro_objects")
+    .whereRaw('point(??, ??) <@ circle( point(?, ?), ?) AND "gmag" < ?;', [
+      "RAdeg",
+      "DECdeg",
+      ra,
+      dec,
+      radius,
+      mag,
+    ]);
+
+  return res;
+};
+
+const getRangeOfAstroObjectsWithLimit = async (ra, dec, radius, mag, limit) => {
   let res = await pool
     .select()
     .from("astro_objects")
@@ -160,8 +182,35 @@ const resolvers = {
       pool = pool || (await createPoolAndEnsureSchema()); // blah
 
       // Validate that the request contains all the params required for the query
-      if (args && args.ra && args.dec && args.radius && args.mag && args.mag) {
+      if (args && args.ra && args.dec && args.radius && args.mag) {
         let res = await getRangeOfAstroObjects(
+          args.ra,
+          args.dec,
+          args.radius,
+          args.mag
+        );
+        return res;
+      } else {
+        writeLog(
+          "The required arguments were not passed to the astro-object-api schema!",
+          "ERROR"
+        );
+      }
+    },
+    async getRangeOfAstroObjectsWithLimit(parent, args) {
+      // Ensure that there is a connection to the DB
+      pool = pool || (await createPoolAndEnsureSchema()); // blah
+
+      // Validate that the request contains all the params required for the query
+      if (
+        args &&
+        args.ra &&
+        args.dec &&
+        args.radius &&
+        args.mag &&
+        args.limit
+      ) {
+        let res = await getRangeOfAstroObjectsWithLimit(
           args.ra,
           args.dec,
           args.radius,


### PR DESCRIPTION
The sonification devs requested a new argument be added to the `getRangeOfAstroObjects` GraphQL Query which limits the number of objects returned from the database. I added this as a nearly identical but separate Query to the original, and left the original included. This way, Skysynth should not error during the short period of time that the API is updated with the new parameter changes but the client is not (updates to the API and client don't go out at the exact same time or complete at the exact same time, it's one then the other).